### PR TITLE
docs: agregar Swagger y estado en endpoint de lote

### DIFF
--- a/apps/backend/src/controllers/batchController.ts
+++ b/apps/backend/src/controllers/batchController.ts
@@ -4,7 +4,6 @@ import { crearLoteSchema } from "../schemas/batchSchema";
 import { AppError } from "../utils/AppError";
 import { ApiResponse } from "../utils/ApiResponse";
 
-
 export const crearLote = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const parsed = crearLoteSchema.safeParse(req.body);
@@ -15,21 +14,11 @@ export const crearLote = async (req: Request, res: Response, next: NextFunction)
         }
 
         const user = (req as any).user;
-
-        if (!user) {
-            throw new AppError("Usuario no autenticado", 401);
-        }
+        if (!user) throw new AppError("Usuario no autenticado", 401);
 
         const lote = await LoteService.crearLote(user.id, parsed.data);
 
-        const response = ApiResponse.success(
-            lote,
-            "Lote creado correctamente",
-            201
-        );
-
-        return res.status(response.statusCode).json(response);
-
+        return res.status(201).json(ApiResponse.success(lote, "Lote creado correctamente", 201));
     } catch (error) {
         next(error);
     }
@@ -38,17 +27,17 @@ export const crearLote = async (req: Request, res: Response, next: NextFunction)
 export const editarLote = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { idLote } = req.params;
+        if (!idLote) throw new AppError("Id de lote requerido", 400);
 
-        if (!idLote) {
-            throw new AppError("Id de lote requerido", 404);
+        const parsed = crearLoteSchema.partial().safeParse(req.body);
+        if (!parsed.success) {
+            const errores = parsed.error.issues.map(e => e.message);
+            throw new AppError(errores.join(", "), 400);
         }
 
-        const lote = await LoteService.editarLote(idLote, req.body);
+        const lote = await LoteService.editarLote(idLote, parsed.data);
 
-        return res
-            .status(200)
-            .json(ApiResponse.success(lote, "Lote actualizado correctamente"));
-
+        return res.status(200).json(ApiResponse.success(lote, "Lote actualizado correctamente"));
     } catch (error) {
         next(error);
     }
@@ -57,26 +46,14 @@ export const editarLote = async (req: Request, res: Response, next: NextFunction
 export const eliminarLote = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const user = (req as any).user;
-
-        if (!user) {
-            throw new AppError("Usuario no autenticado", 401);
-        }
+        if (!user) throw new AppError("Usuario no autenticado", 401);
 
         const { idLote } = req.params;
-
-        if (!idLote) {
-            throw new AppError("Id de lote requerido", 400);
-        }
+        if (!idLote) throw new AppError("Id de lote requerido", 400);
 
         await LoteService.eliminarLote(idLote);
 
-        return res.status(200).json(
-            ApiResponse.success(
-                null,
-                "Lote eliminado correctamente",
-                200
-            )
-        );
+        return res.status(200).json(ApiResponse.success(null, "Lote eliminado correctamente", 200));
     } catch (error) {
         next(error);
     }
@@ -85,43 +62,27 @@ export const eliminarLote = async (req: Request, res: Response, next: NextFuncti
 export const listarLotes = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const user = (req as any).user;
-
-        if (!user) {
-            throw new AppError("Usuario no autenticado", 401);
-        }
+        if (!user) throw new AppError("Usuario no autenticado", 401);
 
         const lotes = await LoteService.listarLotes(user.id);
 
-        return res
-            .status(200)
-            .json(ApiResponse.success(lotes, "Lotes listados correctamente"));
-
+        return res.status(200).json(ApiResponse.success(lotes, "Lotes listados correctamente"));
     } catch (error) {
         next(error);
     }
-
 };
 
 export const obtenerLote = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const user = (req as any).user;
-
-        if (!user) {
-            throw new AppError("Usuario no autenticado", 401);
-        }
+        if (!user) throw new AppError("Usuario no autenticado", 401);
 
         const { idLote } = req.params;
-
-        if (!idLote) {
-            throw new AppError("Id de lote requerido", 400);
-        }
+        if (!idLote) throw new AppError("Id de lote requerido", 400);
 
         const lote = await LoteService.obtenerLote(idLote, user.id);
 
-        return res
-            .status(200)
-            .json(ApiResponse.success(lote, "Lote obtenido correctamente"));
-
+        return res.status(200).json(ApiResponse.success(lote, "Lote obtenido correctamente"));
     } catch (error) {
         next(error);
     }

--- a/apps/backend/src/docs/establishment.swagger.ts
+++ b/apps/backend/src/docs/establishment.swagger.ts
@@ -1,0 +1,74 @@
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     CreateEstablishmentRequest:
+ *       type: object
+ *       required:
+ *         - nombre
+ *         - localidad
+ *         - provincia
+ *       properties:
+ *         nombre:
+ *           type: string
+ *         localidad:
+ *           type: string
+ *         provincia:
+ *           type: string
+ *       example:
+ *         nombre: "Establecimiento Norte"
+ *         localidad: "Rafaela"
+ *         provincia: "Santa Fe"
+ *
+ *     Establishment:
+ *       type: object
+ *       properties:
+ *         idEstablecimiento:
+ *           type: string
+ *           format: uuid
+ *         nombre:
+ *           type: string
+ *         localidad:
+ *           type: string
+ *         provincia:
+ *           type: string
+ *         idUsuario:
+ *           type: string
+ *           format: uuid
+ */
+/**
+ * @swagger
+ * /establecimiento/registrar:
+ *   post:
+ *     tags:
+ *       - establecimiento
+ *     summary: Registrar establecimiento del usuario autenticado
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateEstablishmentRequest'
+ *     responses:
+ *       201:
+ *         description: Establecimiento creado correctamente
+ *       400:
+ *         description: Datos inválidos o usuario ya tiene establecimiento
+ *       401:
+ *         description: Usuario no autenticado
+ *
+ * /establecimiento/listar:
+ *   get:
+ *     tags:
+ *       - establecimiento
+ *     summary: Obtener establecimiento del usuario autenticado
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Establecimiento obtenido correctamente
+ *       401:
+ *         description: Usuario no autenticado
+ */

--- a/apps/backend/src/docs/lote.swagger.ts
+++ b/apps/backend/src/docs/lote.swagger.ts
@@ -1,0 +1,188 @@
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     CrearLoteRequest:
+ *       type: object
+ *       required:
+ *         - idProducto
+ *         - cantidad
+ *         - unidad
+ *         - fechaProduccion
+ *       properties:
+ *         idProducto:
+ *           type: string
+ *           description: ID del producto a asociar
+ *         cantidad:
+ *           type: number
+ *           description: Cantidad producida
+ *         unidad:
+ *           type: string
+ *           enum: [kg, litros]
+ *           description: Unidad de medida
+ *         fechaProduccion:
+ *           type: string
+ *           format: date
+ *           description: Fecha de producción en formato dd/mm/aaaa
+ *         merma:
+ *           type: number
+ *           description: Merma opcional
+ *         estado:
+ *           type: boolean
+ *           description: Estado del lote
+ *       example:
+ *         idProducto: "d290f1ee-6c54-4b01-90e6-d701748f0851"
+ *         cantidad: 100
+ *         unidad: kg
+ *         fechaProduccion: "25/02/2026"
+ *         merma: 2
+ *         estado: false
+ *
+ *     Lote:
+ *       type: object
+ *       properties:
+ *         idLote:
+ *           type: string
+ *           format: uuid
+ *         idProducto:
+ *           type: string
+ *           format: uuid
+ *         cantidad:
+ *           type: number
+ *         unidad:
+ *           type: string
+ *           enum: [kg, litros]
+ *         fechaProduccion:
+ *           type: string
+ *           format: date-time
+ *         estado:
+ *           type: boolean
+ *         producto:
+ *           type: object
+ *           properties:
+ *             nombre:
+ *               type: string
+ *             categoria:
+ *               type: string
+ *
+ * /lote/crear:
+ *   post:
+ *     tags:
+ *       - lote
+ *     summary: Crear un lote de producción
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CrearLoteRequest'
+ *     responses:
+ *       201:
+ *         description: Lote creado correctamente
+ *       400:
+ *         description: Datos inválidos
+ *       401:
+ *         description: Usuario no autenticado
+ *
+ * /lote/editar/{idLote}:
+ *   patch:
+ *     tags:
+ *       - lote
+ *     summary: Editar un lote existente
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: idLote
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CrearLoteRequest'
+ *     responses:
+ *       200:
+ *         description: Lote actualizado correctamente
+ *       400:
+ *         description: Datos inválidos
+ *       401:
+ *         description: Usuario no autenticado
+ *       404:
+ *         description: Lote no encontrado
+ *
+ * /lote/eliminar/{idLote}:
+ *   delete:
+ *     tags:
+ *       - lote
+ *     summary: Eliminar un lote
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: idLote
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Lote eliminado correctamente
+ *       400:
+ *         description: Id de lote requerido
+ *       401:
+ *         description: Usuario no autenticado
+ *       403:
+ *         description: No se puede eliminar el lote (tiene información asociada)
+ *
+ * /lote/listar:
+ *   get:
+ *     tags:
+ *       - lote
+ *     summary: Listar todos los lotes del usuario
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Lotes listados correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Lote'
+ *       401:
+ *         description: Usuario no autenticado
+ *
+ * /lote/{idLote}:
+ *   get:
+ *     tags:
+ *       - lote
+ *     summary: Obtener un lote específico
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: idLote
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Lote obtenido correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Lote'
+ *       400:
+ *         description: Id de lote requerido
+ *       401:
+ *         description: Usuario no autenticado
+ *       403:
+ *         description: No tiene permisos para ver este lote
+ *       404:
+ *         description: Lote no encontrado
+ */

--- a/apps/backend/src/schemas/batchSchema.ts
+++ b/apps/backend/src/schemas/batchSchema.ts
@@ -41,6 +41,7 @@ export const crearLoteSchema = z.object({
             .positive("La merma debe ser mayor a 0")
             .optional()
     ),
+    estado: z.boolean().optional()
 });
 
 export type CrearLoteDTO = z.infer<typeof crearLoteSchema>;


### PR DESCRIPTION
Se actualizó la documentación Swagger para los endpoints de establecimientos y lotes, se agregó el campo estado al endpoint de lote y se refactorizó el manejo de errores, unificando los lanzamientos mediante AppError para mantener consistencia y códigos HTTP correctos.