### PR TITLE
Estilos de comparación historica #82

### DIFF
--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -44,7 +44,7 @@ export const Navbar: React.FC<NavbarProps> = ({ onMenuClick }) => {
       </div>
 
       <div className="flex items-center gap-2 sm:gap-4">
-        <div className="flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5">
+        <div className="hidden md:flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5">
           <MapPin className="h-4 w-4 text-black" />
           <span className="text-xs font-semibold text-gray-700">
             {/* Levantamos los datos desde el establecimiento del usuario */}

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -1,51 +1,38 @@
-import React, { useState, useEffect } from 'react'
-import { MapPin, Clock, Menu } from 'lucide-react'
-import { useAuth } from '../context/AuthContext'
+import React, { useState, useEffect } from 'react';
+import { MapPin, Clock, Menu } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
 // Importamos la interfaz para mantener el tipado correcto
-import { Establecimiento } from '../types'
+import { Establecimiento } from '../types';
 
 interface NavbarProps {
-  onMenuClick: () => void
+  onMenuClick: () => void;
 }
 
 export const Navbar: React.FC<NavbarProps> = ({ onMenuClick }) => {
-  const { user } = useAuth()
-  const [currentTime, setCurrentTime] = useState(new Date())
+  const { user } = useAuth();
+  const [currentTime, setCurrentTime] = useState(new Date());
 
   useEffect(() => {
-    const timer = setInterval(() => setCurrentTime(new Date()), 1000)
-    return () => clearInterval(timer)
-  }, [])
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
 
   // Lógica para obtener el establecimiento:
   // Si establecimientos es un array, tomamos el primero.
-  const establecimientoActivo = Array.isArray(user?.establecimientos)
+  const establecimientoActivo = Array.isArray(user?.establecimientos) 
     ? (user?.establecimientos[0] as Establecimiento)
-    : null
+    : null;
 
   const formatDateTime = (date: Date) => {
-    const days = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
-    const months = [
-      'Ene',
-      'Feb',
-      'Mar',
-      'Abr',
-      'May',
-      'Jun',
-      'Jul',
-      'Ago',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dic',
-    ]
-    return `${days[date.getDay()]}, ${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} | ${date.getHours() % 12 || 12}:${date.getMinutes().toString().padStart(2, '0')} ${date.getHours() >= 12 ? 'PM' : 'AM'}`
-  }
+    const days = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+    const months = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'];
+    return `${days[date.getDay()]}, ${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} | ${date.getHours() % 12 || 12}:${date.getMinutes().toString().padStart(2, '0')} ${date.getHours() >= 12 ? 'PM' : 'AM'}`;
+  };
 
   return (
     <nav className="sticky top-0 z-30 flex h-20 w-full items-center justify-between border-b border-gray-200 bg-white px-4 sm:px-8">
       <div className="flex items-center gap-4">
-        <button
+        <button 
           onClick={onMenuClick}
           className="p-2 rounded-lg transition-colors duration-200 hover:bg-[#4A4A4A] hover:text-white text-[#4A4A4A]"
         >
@@ -61,13 +48,18 @@ export const Navbar: React.FC<NavbarProps> = ({ onMenuClick }) => {
           <MapPin className="h-4 w-4 text-black" />
           <span className="text-xs font-semibold text-gray-700">
             {/* Levantamos los datos desde el establecimiento del usuario */}
-            {establecimientoActivo
+            {establecimientoActivo 
               ? `${establecimientoActivo.localidad}, ${establecimientoActivo.provincia}`
               : 'Córdoba, AR'}
           </span>
         </div>
-        <div className="flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5"></div>
+        <div className="flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5">
+          <Clock className="h-4 w-4 text-black" />
+          <span className="text-[10px] sm:text-xs font-semibold text-gray-700">
+            {formatDateTime(currentTime)}
+          </span>
+        </div>
       </div>
     </nav>
-  )
-}
+  );
+};

--- a/apps/frontend/src/components/shared/dashboard/ComparacionHistorica.tsx
+++ b/apps/frontend/src/components/shared/dashboard/ComparacionHistorica.tsx
@@ -1,0 +1,234 @@
+import React, { useState } from 'react'
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@/src/components/common/card'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/src/components/common/select'
+
+interface ComparacionDataPoint {
+    label: string
+    actual: number
+    comparado: number
+}
+
+interface ComparacionProps {
+    periodo: string
+    setPeriodo: (v: string) => void
+    metrica: string
+    setMetrica: (v: string) => void
+}
+
+// Datos de prueba con un valor muy alto (Ene) para probar el fix
+const DEFAULT_DATA: ComparacionDataPoint[] = [
+    { label: 'Ago', actual: 670, comparado: 270 },
+    { label: 'Sep', actual: 250, comparado: 530 },
+    { label: 'Oct', actual: 490, comparado: 370 },
+    { label: 'Nov', actual: 600, comparado: 290 },
+    { label: 'Dic', actual: 760, comparado: 185 },
+    { label: 'Ene', actual: 1000, comparado: 450 }, // Barra muy alta
+]
+
+const ComparacionHistorica = ({ periodo, setPeriodo, metrica, setMetrica }: ComparacionProps) => {
+    const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
+
+    // Configuración del gráfico
+    const CHART_H = 200
+    const BAR_W = 40
+    const BAR_GAP = 24
+    const Y_AXIS_W = 40
+    const PAD_TOP = 10
+    const PAD_RIGHT = 10
+    const X_LABEL_H = 30
+
+    // Dimensiones del Tooltip para cálculos de colisión
+    const TOOLTIP_W = BAR_W + 30 // 70px
+    const TOOLTIP_H = 45 // Alto del tooltip incluyendo padding
+    const TOOLTIP_OFFSET = 8 // Espacio entre la barra y el tooltip
+
+    const hasData = DEFAULT_DATA && DEFAULT_DATA.length > 0
+    const maxVal = hasData ? Math.max(...DEFAULT_DATA.map((d) => d.actual + d.comparado)) : 0
+    // Ajustamos yMax para dar un pequeño margen superior adicional si la barra es la más alta
+    const yMax = Math.ceil((maxVal * 1.05) / 250) * 250 || 1000
+    const yTicks = [0, 250, 500, 750, 1000, 1250, 1500].filter(v => v <= yMax)
+    const barAreaH = CHART_H - PAD_TOP
+
+    const toY = (val: number) => PAD_TOP + barAreaH - (val / yMax) * barAreaH
+    const svgW = Y_AXIS_W + DEFAULT_DATA.length * (BAR_W + BAR_GAP) + PAD_RIGHT
+    const svgH = CHART_H + X_LABEL_H
+
+    return (
+        <Card className="w-full overflow-hidden">
+            <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+                <div>
+                    <CardTitle className="text-lg font-bold">Comparación histórica</CardTitle>
+                    <p className="text-muted-foreground text-xs">Visualizando {metrica} por {periodo}</p>
+                </div>
+                {/* ... Selects iguales ... */}
+                <div className="flex gap-2 w-full sm:w-auto">
+                    <Select value={periodo} onValueChange={setPeriodo}>
+                        <SelectTrigger size="sm" className="w-[110px]">
+                            <SelectValue placeholder="Periodo" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="Día">Día</SelectItem>
+                            <SelectItem value="Quincena">Quincena</SelectItem>
+                            <SelectItem value="Mes">Mes</SelectItem>
+                        </SelectContent>
+                    </Select>
+
+                    <Select value={metrica} onValueChange={setMetrica}>
+                        <SelectTrigger size="sm" className="w-[130px]">
+                            <SelectValue placeholder="Métrica" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="Producción">Producción</SelectItem>
+                            <SelectItem value="Mermas">Mermas</SelectItem>
+                            <SelectItem value="Costo">Costo</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+            </CardHeader>
+
+            <CardContent className="pt-0">
+                {!hasData ? (
+                    <div className="h-[240px] flex flex-col items-center justify-center text-center p-6 bg-[#f9f9f9] rounded-lg border-2 border-dashed border-[#e0e0e0]">
+                        <p className="text-sm font-medium text-gray-500">No existen datos registrados.</p>
+                    </div>
+                ) : (
+                    <div className="overflow-x-auto pb-4 custom-scrollbar">
+                        <svg
+                            viewBox={`0 0 ${svgW} ${svgH}`}
+                            preserveAspectRatio="xMinYMin meet"
+                            className="block overflow-visible mx-auto min-w-[500px] h-full w-full"
+                        >
+                            <defs>
+                                <pattern id="hatch" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
+                                    <line x1="0" y1="0" x2="0" y2="4" stroke="#c2c2c2" strokeWidth="2" />
+                                </pattern>
+                            </defs>
+
+                            {/* Grid Lines */}
+                            {yTicks.map((tick) => (
+                                <g key={tick}>
+                                    <line x1={Y_AXIS_W} y1={toY(tick)} x2={svgW} y2={toY(tick)} className="stroke-border" strokeWidth="1" />
+                                    <text x={Y_AXIS_W - 10} y={toY(tick) + 4} textAnchor="end" className="fill-muted-foreground text-[10px]">
+                                        {tick >= 1000 ? `${tick / 1000}k` : tick}
+                                    </text>
+                                </g>
+                            ))}
+
+                            {/* Bars */}
+                            {DEFAULT_DATA.map((d, i) => {
+                                const x = Y_AXIS_W + i * (BAR_W + BAR_GAP)
+                                const totalValue = d.actual + d.comparado
+                                const actualH = (d.actual / yMax) * barAreaH
+                                const compH = (d.comparado / yMax) * barAreaH
+                                const yActual = CHART_H - actualH
+                                const yComp = CHART_H - (actualH + compH) // PUNTA DE LA BARRA
+
+                                // --- LÓGICA DE CORRECCIÓN DEL TOOLTIP ---
+                                // 1. Calculamos la posición Y por defecto (encima de la barra)
+                                let tooltipY = yComp - TOOLTIP_H - TOOLTIP_OFFSET
+                                let isFlipped = false
+
+                                // 2. Detectamos colisión con el borde superior del SVG (PAD_TOP)
+                                // Si tooltipY es menor que PAD_TOP, significa que se corta arriba.
+                                if (tooltipY < PAD_TOP) {
+                                    // Lo volteamos: dibujamos DEBAJO de la punta de la barra
+                                    tooltipY = yComp + TOOLTIP_OFFSET
+                                    isFlipped = true
+                                }
+
+                                // Centramos el tooltip horizontalmente respecto a la barra
+                                const tooltipX = x + BAR_W / 2 - TOOLTIP_W / 2
+
+                                return (
+                                    <g key={d.label} onMouseEnter={() => setHoveredIdx(i)} onMouseLeave={() => setHoveredIdx(null)}>
+                                        {/* Barras */}
+                                        <rect x={x} y={yActual} width={BAR_W} height={actualH} fill="#cbcbcb" rx="2" />
+                                        <rect x={x} y={yComp} width={BAR_W} height={compH} fill="url(#hatch)" stroke="#c2c2c2" rx="2" />
+
+                                        {/* Etiquetas X */}
+                                        <text x={x + BAR_W / 2} y={CHART_H + 20} textAnchor="middle" className="fill-muted-foreground text-[11px] font-medium">
+                                            {d.label}
+                                        </text>
+
+                                        {/* Tooltip Inteligente */}
+                                        {hoveredIdx === i && (
+                                            <g className="pointer-events-none transition-transform duration-150 ease-in-out">
+                                                {/* Fondo del Tooltip */}
+                                                <rect
+                                                    x={tooltipX}
+                                                    y={tooltipY}
+                                                    width={TOOLTIP_W}
+                                                    height={TOOLTIP_H}
+                                                    rx="6"
+                                                    fill="#1c1c1c"
+                                                    className="shadow-xl"
+                                                />
+
+                                                {/* Triángulo indicador (Opcional, ayuda visualmente) */}
+                                                <path
+                                                    d={isFlipped
+                                                        ? `M${x + BAR_W / 2} ${tooltipY} L${x + BAR_W / 2 - 6} ${tooltipY - 6} L${x + BAR_W / 2 + 6} ${tooltipY - 6} Z` // Triángulo hacia arriba
+                                                        : `M${x + BAR_W / 2} ${yComp - TOOLTIP_OFFSET} L${x + BAR_W / 2 - 6} ${yComp - TOOLTIP_OFFSET + 6} L${x + BAR_W / 2 + 6} ${yComp - TOOLTIP_OFFSET + 6} Z` // Triángulo hacia abajo
+                                                    }
+                                                    fill="#1c1c1c"
+                                                    transform={isFlipped ? `translate(0, 0)` : `translate(0, -6)`}
+                                                />
+
+                                                {/* Contenido del Tooltip */}
+                                                <text
+                                                    x={tooltipX + TOOLTIP_W / 2}
+                                                    y={tooltipY + 20} // Ajuste vertical del texto dentro del rect
+                                                    textAnchor="middle"
+                                                    fill="white"
+                                                    className="text-[11px] font-bold tracking-tight"
+                                                >
+                                                    {totalValue.toLocaleString('es-AR')} {/* Formato de miles */}
+                                                </text>
+                                                <text
+                                                    x={tooltipX + TOOLTIP_W / 2}
+                                                    y={tooltipY + 33}
+                                                    textAnchor="middle"
+                                                    fill="#aaaaaa"
+                                                    className="text-[9px] font-medium"
+                                                >
+                                                    Total {metrica}
+                                                </text>
+                                            </g>
+                                        )}
+                                    </g>
+                                )
+                            })}
+                        </svg>
+                    </div>
+                )}
+
+                {/* Legend ... igual ... */}
+                <div className="flex justify-center gap-6 mt-4 border-t pt-4">
+                    <div className="flex items-center gap-2">
+                        <div className="size-3 rounded-sm border border-[#c2c2c2] overflow-hidden bg-white">
+                            <svg width="12" height="12"><rect width="12" height="12" fill="url(#hatch)" /></svg>
+                        </div>
+                        <span className="text-xs text-muted-foreground font-medium">Mes comparado</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <div className="size-3 rounded-sm bg-[#cbcbcb]" />
+                        <span className="text-xs text-muted-foreground font-medium">Actual</span>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}
+
+export default ComparacionHistorica

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -45,11 +45,6 @@ const Dashboard = () => {
           value="$811.000"
           description="Total acumulado"
         />
-        <StatCard
-          title="Costo Unitario (CPU)"
-          value="$2.053"
-          description="Costo por unidad"
-        />
       </div>
 
       {/* Cuerpo Principal */}

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -26,24 +26,28 @@ const Dashboard = () => {
       {/* Seccion de Stats - 5 indicadores según requerimiento */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         <StatCard
-          title="Producción Total"
+          title="Queso Producido"
           value="395 Kg"
-          description={`Período: ${periodo}`}
+          trend={{ value: 12, isPositive: true }}
+          description="vs Enero"
         />
         <StatCard
-          title="Total de Mermas"
-          value="45 Kg"
-          description={`Período: ${periodo}`}
+          title="Leche Vendida"
+          value="810 L"
+          trend={{ value: 8, isPositive: true }}
+          description="vs Enero"
         />
         <StatCard
-          title="% Merma"
-          value="11.4%"
-          description="Basado en producción"
+          title="Mermas Totales"
+          value="45 Kg/L"
+          trend={{ value: 15, isPositive: false }}
+          description="vs Enero"
         />
         <StatCard
-          title="Costos Directos"
+          title="Costo directo total"
           value="$811.000"
-          description="Total acumulado"
+          trend={{ value: 5, isPositive: true }}
+          description="vs Enero"
         />
       </div>
 

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,12 +1,17 @@
+import { useState } from 'react'
 import AlertsSection from '@/src/components/shared/dashboard/AlertsSection'
 import { StatCard } from '../components/shared/StatCard'
 import DailyProductionLog from '../components/shared/dashboard/DailyProductionLog'
+import ComparacionHistorica from '../components/shared/dashboard/ComparacionHistorica'
 
 const Dashboard = () => {
+  // 1. Definimos el estado centralizado que requiere el componente
+  const [periodo, setPeriodo] = useState('Mes')
+  const [metrica, setMetrica] = useState('Producción')
+
   return (
-    // min-h-screen y w-full aseguran que el contenedor no se desborde
     <div className="space-y-6 w-full max-w-full overflow-x-hidden">
-      {/* Cabecera del Dashboard - Responsive */}
+      {/* Cabecera */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 border-b pb-6">
         <div>
           <p className="text-muted-foreground text-xs sm:text-sm">
@@ -18,40 +23,53 @@ const Dashboard = () => {
         </div>
       </div>
 
-      {/* Seccion de Stats - Sistema de Grid Adaptativo */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {/* Seccion de Stats - 5 indicadores según requerimiento */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         <StatCard
-          title="Queso Producido"
+          title="Producción Total"
           value="395 Kg"
-          trend={{ value: 12, isPositive: true }}
-          description="vs Enero"
+          description={`Período: ${periodo}`}
         />
         <StatCard
-          title="Leche Vendida"
-          value="810 L"
-          trend={{ value: 8, isPositive: true }}
-          description="vs Enero"
+          title="Total de Mermas"
+          value="45 Kg"
+          description={`Período: ${periodo}`}
         />
         <StatCard
-          title="Mermas Totales"
-          value="45 Kg/L"
-          trend={{ value: 15, isPositive: false }}
-          description="vs Enero"
+          title="% Merma"
+          value="11.4%"
+          description="Basado en producción"
         />
         <StatCard
-          title="Costo directo total"
+          title="Costos Directos"
           value="$811.000"
-          trend={{ value: 5, isPositive: true }}
-          description="vs Enero"
+          description="Total acumulado"
+        />
+        <StatCard
+          title="Costo Unitario (CPU)"
+          value="$2.053"
+          description="Costo por unidad"
         />
       </div>
 
-      {/* Contenedor para el log de producción - Manejo de ancho total */}
-      <div className="flex flex-col sm:flex-row gap-4 mt-8 w-full overflow-x-auto">
-        <div className="w-full sm:w-2/3 lg:w-3/4">
+      {/* Cuerpo Principal */}
+      <div className="flex flex-col lg:flex-row gap-6 w-full">
+        {/* Columna Izquierda */}
+        <div className="flex-1 flex flex-col gap-6 min-w-0">
+          {/* 2. Pasamos las propiedades requeridas para solucionar el error de TS */}
+          <ComparacionHistorica 
+            periodo={periodo} 
+            setPeriodo={setPeriodo} 
+            metrica={metrica} 
+            setMetrica={setMetrica} 
+          />
           <DailyProductionLog />
         </div>
-        <AlertsSection />
+
+        {/* Columna Derecha */}
+        <aside className="w-full lg:w-80 flex-shrink-0">
+          <AlertsSection />
+        </aside>
       </div>
     </div>
   )


### PR DESCRIPTION
feat: :sparkles: agregar sección de comparación histórica e indicadores operativos

- Añadir componente ComparacionHistorica con gráfico SVG interactivo.  
- Implementar filtros por período (Día, Quincena, Mes) y métrica.  
- Agregar tarjetas de resumen para Producción, Mermas, %, Costos y CPU.  
- Corregir error en la barra de navegación que faltaba contenido tras merge con develop.  
- Implementar estado vacío y diseño responsivo para las métricas del dashboard.