### PR TITLE
106 Carga de lote con fecha del día 

### DIFF
--- a/apps/frontend/src/hooks/batch/useBatchesDay.ts
+++ b/apps/frontend/src/hooks/batch/useBatchesDay.ts
@@ -10,8 +10,6 @@ export function useBatchesDay() {
       return data
     },
     staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    retry: false,
+    refetchOnWindowFocus: true,
   })
 }

--- a/apps/frontend/src/hooks/batch/useCreateBatch.ts
+++ b/apps/frontend/src/hooks/batch/useCreateBatch.ts
@@ -22,10 +22,12 @@ export function useCreateBatch() {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.batch.lists() })
+      queryClient.invalidateQueries({ queryKey: queryKeys.batch.day() })
     },
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.batch.lists() })
+      queryClient.invalidateQueries({ queryKey: queryKeys.batch.day() })
     },
   })
 }


### PR DESCRIPTION
# Se corrige la actualización de los productos del dia

Los productos no estaban cargando correctamente en la página dashboard cuando cargabas un nuevo lote el mismo dia